### PR TITLE
Add support to use Google application default credential

### DIFF
--- a/tests/test_rpchelper.py
+++ b/tests/test_rpchelper.py
@@ -33,8 +33,7 @@ class RpcHelperTestCase(unittest.TestCase):
   def setUp(self):
     self.api_url = '/widget'
     self.service_email = 'dev@content.google.com'
-    self.rpchelper = rpchelper.RpcHelper(self.service_email, '', self.api_url,
-                                         'api_key', None)
+    self.rpchelper = rpchelper.RpcHelper(self.service_email, '', self.api_url, None, False)
 
   def testGitkitClientError(self):
     error_response = {


### PR DESCRIPTION
1. Add support to use Google application default credential, so that developers don't need to provide service account and private key when the app is deployed on app engine;
2. Use getProjectConfig to get API key, sign in options and client ID, so that developers don't need to hardcode these values in the code.