### PR TITLE
remove use_app_default_credentials flag

### DIFF
--- a/identitytoolkit/gitkitclient.py
+++ b/identitytoolkit/gitkitclient.py
@@ -169,8 +169,7 @@ class GitkitClient(object):
   CHANGE_EMAIL_ACTION = 'changeEmail'
 
   def __init__(self, client_id='', service_account_email='', service_account_key='',
-               widget_url='', cookie_name='gtoken', http=None,
-               use_app_default_credentials=True):
+               widget_url='', cookie_name='gtoken', http=None):
     """Inits the Gitkit client library.
 
     Args:
@@ -180,7 +179,6 @@ class GitkitClient(object):
       widget_url: string, Gitkit widget URL.
       cookie_name: string, Gitkit cookie name.
       http: Http, http client which support cache.
-      use_app_default_credentials: bool, whether to use app default credentials.
     """
     self.client_id = client_id
     self.widget_url = widget_url
@@ -188,8 +186,7 @@ class GitkitClient(object):
     self.rpc_helper = rpchelper.RpcHelper(service_account_email,
                                           service_account_key,
                                           GitkitClient.GOOGLE_API_BASE,
-                                          http,
-                                          use_app_default_credentials)
+                                          http)
     self.config_data_cached = None
     if not self.client_id:
       self.client_id = self.GetClientId()
@@ -239,8 +236,7 @@ class GitkitClient(object):
         json_data['serviceAccountEmail'],
         key,
         json_data['widgetUrl'],
-        json_data['cookieName'],
-        use_app_default_credentials=False)
+        json_data['cookieName'])
 
   def VerifyGitkitToken(self, jwt):
     """Verifies a Gitkit token string.

--- a/tests/test_gitkitclient.py
+++ b/tests/test_gitkitclient.py
@@ -36,8 +36,7 @@ class GitkitClientTestCase(unittest.TestCase):
     self.user_name = 'Joe'
     self.user_photo = 'http://idp.com/photo'
     self.gitkitclient = gitkitclient.GitkitClient(client_id='client_id',
-                                                  widget_url=self.widget_url,
-                                                  use_app_default_credentials=False)
+                                                  widget_url=self.widget_url)
 
   def testGetClientId(self):
     expected_client_id = 'client_id'

--- a/tests/test_rpchelper.py
+++ b/tests/test_rpchelper.py
@@ -33,7 +33,10 @@ class RpcHelperTestCase(unittest.TestCase):
   def setUp(self):
     self.api_url = '/widget'
     self.service_email = 'dev@content.google.com'
-    self.rpchelper = rpchelper.RpcHelper(self.service_email, '', self.api_url, None, False)
+    self.rpchelper = rpchelper.RpcHelper(self.service_email,
+                                         'service_key',
+                                          self.api_url,
+                                          None)
 
   def testGitkitClientError(self):
     error_response = {


### PR DESCRIPTION
Service account credentials are set in the following orders:
1. Non-empty service account email and service account private key value passed in from __init__ in GitkitClient;
2. Use [Google application default credentials](https://developers.google.com/identity/protocols/application-default-credentials) if no service account email or service account private key are passed in;
3. If application default credentials are not found, GitkitClient is still created without throwing error. Error will be thrown when calling APIs that require service account credentials